### PR TITLE
Ignore Unix Hidden Files for Analogy Task

### DIFF
--- a/vecto/benchmarks/analogy/analogy.py
+++ b/vecto/benchmarks/analogy/analogy.py
@@ -165,6 +165,8 @@ class Analogy(Benchmark):
         results = []
         dataset = Dataset(path_dataset)
         for filename in dataset.file_iterator():
+            if filename.split('/')[-1][0] == '.':
+                continue
             logger.info("processing " + filename)
             pairs = get_pairs(filename)
             name_category = os.path.basename(os.path.dirname(filename))


### PR DESCRIPTION
The unix-like systems like mac and linux distributions will automatically create some hidden files whose names are started with '.' under the data folders, which makes the analogy.py down
I simply add 2 lines to let it ignore such files.