### PR TITLE
remove f-format string

### DIFF
--- a/vecto/benchmarks/visualize.py
+++ b/vecto/benchmarks/visualize.py
@@ -56,7 +56,7 @@ def df_from_file(path):
     try:
         default_measurement = dframe["experiment_setup.default_measurement"].unique()[0]
     except KeyError:
-        logger.warning(f"default_measurement not specified in {path}")
+        logger.warning("default_measurement not specified in %s" % (path))
     dframe["result"] = dframe["result." + default_measurement]
     # df["reciprocal_rank"] = 1 / (df["rank"] + 1)
     return dframe
@@ -71,7 +71,7 @@ def df_from_dir(path):
                 try:
                     dfs.append(df_from_file(full_path))
                 except KeyError:
-                    logger.warning(f"error reading {full_path}")
+                    logger.warning("error reading %s" % (full_path))
     dframe = pandas.concat(dfs, sort=True)
     # print(dframe["experiment_setup.task"])
     return dframe

--- a/vecto/cli.py
+++ b/vecto/cli.py
@@ -18,7 +18,7 @@ The most commonly used vecto commands are:
 ''')
 
         parser.add_argument('--version', action='version',
-                            version=f'Vecto version {vecto.__version__}')
+                            version='Vecto version %s' % (vecto.__version__))
         parser.add_argument('command', help='Subcommand to run')
         args, self.unknownargs = parser.parse_known_args()
         if not hasattr(self, args.command):


### PR DESCRIPTION
this feature is for py3.6+ only, otherwise running cli will return error:

> SyntaxError: invalid syntax

`README` says vector should support py3.5, so I replace f-strings with %-formatting here.